### PR TITLE
allow file credentials have empty username and password

### DIFF
--- a/MYOB.API.SDK/SDK/Communication/ApiRequestHelper.cs
+++ b/MYOB.API.SDK/SDK/Communication/ApiRequestHelper.cs
@@ -124,7 +124,7 @@ namespace MYOB.AccountRight.SDK.Communication
             request.Headers["x-myobapi-key"] = configuration.ClientId;
             request.Headers["x-myobapi-version"] = "v2";
 
-            if (credentials != null)
+            if ((credentials != null) && (!String.IsNullOrEmpty(credentials.Username))) // password can be empty
             {
                 request.Headers["x-myobapi-cftoken"] = Convert.ToBase64String(Encoding.UTF8.GetBytes(string.Format("{0}:{1}",
                     credentials.Username.Maybe(_ => _, string.Empty), credentials.Password.Maybe(_ => _, string.Empty))));


### PR DESCRIPTION
if user is linked to my.myob, the username and password can be empty. In
that case, the program should send an empty x-myobapi-cftoken instead of
a colon(":" ) x-myobapi-cftoken.