### PR TITLE
Support gender of 'Indeterminate'

### DIFF
--- a/MYOB.API.SDK/SDK/Contracts/Version2/Contact/EmployeePayrollDetails.cs
+++ b/MYOB.API.SDK/SDK/Contracts/Version2/Contact/EmployeePayrollDetails.cs
@@ -24,7 +24,12 @@ namespace MYOB.AccountRight.SDK.Contracts.Version2.Contact
         /// <summary>
         /// Female
         /// </summary>
-        Female = 2
+        Female = 2,
+        
+        /// <summary>
+        /// Indeterminate
+        /// </summary>
+        Indeterminate = 3
     }
 
     /// <summary>


### PR DESCRIPTION
At present, fetching EmployeePayrollDetails fails if one of the Entries' gender fields is set to "Indeterminate".

This change rectifies the issue.