### PR TITLE
add country code to company file

### DIFF
--- a/MYOB.API.SDK/SDK/Contracts/CompanyFile.cs
+++ b/MYOB.API.SDK/SDK/Contracts/CompanyFile.cs
@@ -37,5 +37,10 @@ namespace MYOB.AccountRight.SDK.Contracts
         /// Uri of the resource
         /// </summary>
         public Uri Uri { get; set; }
+
+        /// <summary>
+        /// Country code.
+        /// </summary>
+        public String Country { get; set; }
     }
 }


### PR DESCRIPTION
according to this, the company file has a country field.
http://developer.myob.com/api/accountright/v2/company-files/

This field is helpful to identify whether the user is NZ or AU for tax purpose.