### PR TITLE
Feature/navigable paged collection

### DIFF
--- a/MYOB.API.SDK/SDK.Test/Services/ReadableServiceTests.cs
+++ b/MYOB.API.SDK/SDK.Test/Services/ReadableServiceTests.cs
@@ -22,7 +22,14 @@ namespace SDK.Test.Services
     {
         public class TestReadOnlyService : ReadableService<UserContract>
         {
-            public TestReadOnlyService(IApiConfiguration configuration, IWebRequestFactory webRequestFactory, IOAuthKeyService keyService) : base(configuration, webRequestFactory, keyService)
+            public TestReadOnlyService(
+                IApiConfiguration configuration,
+                IWebRequestFactory webRequestFactory,
+                IOAuthKeyService keyService)
+            : base(
+                configuration,
+                webRequestFactory,
+                keyService)
             {
             }
 
@@ -49,19 +56,19 @@ namespace SDK.Test.Services
 
         private readonly Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>[] _getActions = new[]
             {
-                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("Async", 
+                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("Async",
                     (service, cf) =>
                     {
                         UserContract received = null;
                         service.Get(cf, _uid, null, (code, files) => { received = files; }, (uri, exception) => Assert.Fail(exception.Message));
                         return received;
                     }),
-                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("Sync", 
+                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("Sync",
                     (service, cf) =>
                     {
                         return service.Get(cf, _uid, null);
                     }),
-                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("Async", 
+                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("Async",
                     (service, cf) =>
                     {
                         return service.GetAsync(cf, _uid, null).Result;
@@ -85,24 +92,24 @@ namespace SDK.Test.Services
 
         private readonly Tuple<string, Func<TestReadOnlyService, CompanyFile, PagedCollection<UserContract>>>[] _getRangeActions = new[]
             {
-                new Tuple<string, Func<TestReadOnlyService, CompanyFile, PagedCollection<UserContract>>>("Delegate", 
+                new Tuple<string, Func<TestReadOnlyService, CompanyFile, PagedCollection<UserContract>>>("Delegate",
                     (service, cf) =>
                     {
                         PagedCollection<UserContract> received = null;
                         service.GetRange(cf, null, null, (code, files) => { received = files; }, (uri, exception) => Assert.Fail(exception.Message));
                         return received;
                     }),
-                new Tuple<string, Func<TestReadOnlyService, CompanyFile, PagedCollection<UserContract>>>("Sync", 
+                new Tuple<string, Func<TestReadOnlyService, CompanyFile, PagedCollection<UserContract>>>("Sync",
                     (service, cf) =>
                     {
                         return service.GetRange(cf, null, null);
                     }),
-                new Tuple<string, Func<TestReadOnlyService, CompanyFile, PagedCollection<UserContract>>>("Async", 
+                new Tuple<string, Func<TestReadOnlyService, CompanyFile, PagedCollection<UserContract>>>("Async",
                     (service, cf) =>
                     {
                         return service.GetRangeAsync(cf, null, null).Result;
                     }),
-                new Tuple<string, Func<TestReadOnlyService, CompanyFile, PagedCollection<UserContract>>>("AsyncWithCancel", 
+                new Tuple<string, Func<TestReadOnlyService, CompanyFile, PagedCollection<UserContract>>>("AsyncWithCancel",
                     (service, cf) =>
                     {
                         return service.GetRangeAsync(cf, null, null, CancellationToken.None).Result;
@@ -116,7 +123,7 @@ namespace SDK.Test.Services
             // arrange
             var cf = new CompanyFile() { Uri = new Uri("https://dc1.api.myob.com/accountright/7D5F5516-AF68-4C5B-844A-3F054E00DF10") };
             _webFactory.RegisterResultForUri(cf.Uri.AbsoluteUri + "/Test/User/Contract", new PagedCollection<UserContract> { Count = 1, Items = new[] { new UserContract() { UID = _uid } } }.ToJson());
-            
+
             // act
             var received = action.Item2(_service, cf);
 
@@ -126,19 +133,19 @@ namespace SDK.Test.Services
 
         private readonly Tuple<string, Func<TestReadOnlyService, CompanyFile, PagedCollection<UserContract>>>[] _getRangeQueryActions = new[]
             {
-                new Tuple<string, Func<TestReadOnlyService, CompanyFile, PagedCollection<UserContract>>>("Delegate", 
+                new Tuple<string, Func<TestReadOnlyService, CompanyFile, PagedCollection<UserContract>>>("Delegate",
                     (service, cf) =>
                     {
                         PagedCollection<UserContract> received = null;
                         service.GetRange(cf, "$filter=UID eq guid'2BB63466-1A6C-4757-B3B8-D8B799D641E9'", null, (code, files) => { received = files; }, (uri, exception) => Assert.Fail(exception.Message));
                         return received;
                     }),
-                new Tuple<string, Func<TestReadOnlyService, CompanyFile, PagedCollection<UserContract>>>("Sync", 
+                new Tuple<string, Func<TestReadOnlyService, CompanyFile, PagedCollection<UserContract>>>("Sync",
                     (service, cf) =>
                     {
                         return service.GetRange(cf, "$filter=UID eq guid'2BB63466-1A6C-4757-B3B8-D8B799D641E9'", null);
                     }),
-                new Tuple<string, Func<TestReadOnlyService, CompanyFile, PagedCollection<UserContract>>>("Async", 
+                new Tuple<string, Func<TestReadOnlyService, CompanyFile, PagedCollection<UserContract>>>("Async",
                     (service, cf) =>
                     {
                         return service.GetRangeAsync(cf, "$filter=UID eq guid'2BB63466-1A6C-4757-B3B8-D8B799D641E9'", null).Result;
@@ -162,19 +169,19 @@ namespace SDK.Test.Services
 
         private readonly Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>[] _getByUriActions = new[]
             {
-                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("Async", 
+                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("Async",
                     (service, cf) =>
                     {
                         UserContract received = null;
                         service.Get(cf, new Uri(cf.Uri.AbsoluteUri + "/Test/User/Contract/" + _uid.ToString().ToUpper()), null, (code, files) => { received = files; }, (uri, exception) => Assert.Fail(exception.Message));
                         return received;
                     }),
-                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("Sync", 
+                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("Sync",
                     (service, cf) =>
                     {
                         return service.Get(cf, new Uri(cf.Uri.AbsoluteUri + "/Test/User/Contract/" + _uid), null);
                     }),
-                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("Async", 
+                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("Async",
                     (service, cf) =>
                     {
                         return service.GetAsync(cf, new Uri(cf.Uri.AbsoluteUri + "/Test/User/Contract/" + _uid), null).Result;
@@ -197,53 +204,53 @@ namespace SDK.Test.Services
 
         private readonly Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>[] _getByInvalidUriActions = new[]
             {
-                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("DelegateBadCF", 
+                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("DelegateBadCF",
                     (service, cf) =>
                     {
                         UserContract received = null;
                         service.Get(cf, new Uri("http://localhost/accountright" + "/Test/User/Contract/" + _uid.ToString().ToUpper()), null, (code, files) => { received = files; }, (uri, exception) => Assert.Fail(exception.Message));
                         return received;
                     }),
-                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("SyncBadCF", 
+                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("SyncBadCF",
                     (service, cf) =>
                     {
                         return service.Get(cf, new Uri("http://localhost/accountright" + "/Test/User/Contract/" + _uid), null);
                     }),
-                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("AsyncBadCF", 
+                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("AsyncBadCF",
                     (service, cf) =>
                     {
                         return service.GetAsync(cf, new Uri("http://localhost/accountright" + "/Test/User/Contract/" + _uid), null).Result;
                     }),
-                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("DelegateBadRoute", 
+                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("DelegateBadRoute",
                     (service, cf) =>
                     {
                         UserContract received = null;
                         service.Get(cf, new Uri(cf.Uri.AbsoluteUri + "/Test/UnexpectedRoute/" + _uid.ToString().ToUpper()), null, (code, files) => { received = files; }, (uri, exception) => Assert.Fail(exception.Message));
                         return received;
                     }),
-                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("SyncBadRoute", 
+                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("SyncBadRoute",
                     (service, cf) =>
                     {
                         return service.Get(cf, new Uri(cf.Uri.AbsoluteUri + "/Test/UnexpectedRoute/" + _uid.ToString().ToUpper()), null);
                     }),
-                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("AsyncBadRoute", 
+                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("AsyncBadRoute",
                     (service, cf) =>
                     {
                         return service.GetAsync(cf, new Uri(cf.Uri.AbsoluteUri + "/Test/UnexpectedRoute/" + _uid.ToString().ToUpper()), null).Result;
                     }),
-                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("DelegateInvalidUID", 
+                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("DelegateInvalidUID",
                     (service, cf) =>
                     {
                         UserContract received = null;
                         service.Get(cf, new Uri(cf.Uri.AbsoluteUri + "/Test/User/Contract/" + "Item1"), null, (code, files) => { received = files; }, (uri, exception) => Assert.Fail(exception.Message));
                         return received;
                     }),
-                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("SyncInvalidUID", 
+                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("SyncInvalidUID",
                     (service, cf) =>
                     {
                         return service.Get(cf, new Uri(cf.Uri.AbsoluteUri + "/Test/User/Contract/" + "Item1"), null);
                     }),
-                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("AsyncInvalidUID", 
+                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("AsyncInvalidUID",
                     (service, cf) =>
                     {
                         return service.GetAsync(cf, new Uri(cf.Uri.AbsoluteUri + "/Test/User/Contract/" + "Item1"), null).Result;
@@ -264,19 +271,19 @@ namespace SDK.Test.Services
 
         private readonly Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>[] _getByUriActionsEtag = new[]
             {
-                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("Async", 
+                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("Async",
                     (service, cf) =>
                     {
                         UserContract received = null;
                         service.Get(cf, new Uri(cf.Uri.AbsoluteUri + "/Test/User/Contract/" + _uid.ToString().ToUpper()), null, (code, files) => { received = files; }, (uri, exception) => Assert.Fail(exception.Message), "987654321");
                         return received;
                     }),
-                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("Sync", 
+                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("Sync",
                     (service, cf) =>
                     {
                         return service.Get(cf, new Uri(cf.Uri.AbsoluteUri + "/Test/User/Contract/" + _uid), null, "987654321");
                     }),
-                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("Async", 
+                new Tuple<string, Func<TestReadOnlyService, CompanyFile, UserContract>>("Async",
                     (service, cf) =>
                     {
                         return service.GetAsync(cf, new Uri(cf.Uri.AbsoluteUri + "/Test/User/Contract/" + _uid), null, "987654321").Result;
@@ -290,7 +297,7 @@ namespace SDK.Test.Services
             var cf = new CompanyFile() { Uri = new Uri("https://dc1.api.myob.com/accountright/7D5F5516-AF68-4C5B-844A-3F054E00DF10") };
             _webFactory.RegisterResultForUri(cf.Uri.AbsoluteUri + "/Test/User/Contract/" + _uid, new UserContract() { UID = _uid }.ToJson());
             HttpWebRequest request = null;
-            _webFactory.CreatedWebRequest += _ => request = (HttpWebRequest)_; 
+            _webFactory.CreatedWebRequest += _ => request = (HttpWebRequest)_;
 
             // act
             var received = action.Item2(_service, cf);
@@ -301,24 +308,24 @@ namespace SDK.Test.Services
 
         private readonly Tuple<string, Func<TestReadOnlyService, CompanyFile, PagedCollection<UserContract>>>[] _getRangeActionsEtag = new[]
             {
-                new Tuple<string, Func<TestReadOnlyService, CompanyFile, PagedCollection<UserContract>>>("Delegate", 
+                new Tuple<string, Func<TestReadOnlyService, CompanyFile, PagedCollection<UserContract>>>("Delegate",
                     (service, cf) =>
                     {
                         PagedCollection<UserContract> received = null;
                         service.GetRange(cf, null, null, (code, files) => { received = files; }, (uri, exception) => Assert.Fail(exception.Message), "987654321");
                         return received;
                     }),
-                new Tuple<string, Func<TestReadOnlyService, CompanyFile, PagedCollection<UserContract>>>("Sync", 
+                new Tuple<string, Func<TestReadOnlyService, CompanyFile, PagedCollection<UserContract>>>("Sync",
                     (service, cf) =>
                     {
                         return service.GetRange(cf, null, null, "987654321");
                     }),
-                new Tuple<string, Func<TestReadOnlyService, CompanyFile, PagedCollection<UserContract>>>("Async", 
+                new Tuple<string, Func<TestReadOnlyService, CompanyFile, PagedCollection<UserContract>>>("Async",
                     (service, cf) =>
                     {
                         return service.GetRangeAsync(cf, null, null, "987654321").Result;
                     }),
-                new Tuple<string, Func<TestReadOnlyService, CompanyFile, PagedCollection<UserContract>>>("AsyncWithCancel", 
+                new Tuple<string, Func<TestReadOnlyService, CompanyFile, PagedCollection<UserContract>>>("AsyncWithCancel",
                     (service, cf) =>
                     {
                         return service.GetRangeAsync(cf, null, null, CancellationToken.None, "987654321").Result;
@@ -327,19 +334,131 @@ namespace SDK.Test.Services
 
 
         [Test]
-        public void GetRange_IfRequestIsMadeWithETag_IfNoneMatchHeaderIsAttachedToRequest([ValueSource("_getRangeActionsEtag")] Tuple<string, Func<TestReadOnlyService, CompanyFile, PagedCollection<UserContract>>> action)
+        public void GetRange_IfRequestIsMadeWithETag_IfNoneMatchHeaderIsAttachedToRequest(
+            [ValueSource("_getRangeActionsEtag")]
+            Tuple<string, Func<TestReadOnlyService, CompanyFile, PagedCollection<UserContract>>> action)
         {
             // arrange
-            var cf = new CompanyFile() { Uri = new Uri("https://dc1.api.myob.com/accountright/7D5F5516-AF68-4C5B-844A-3F054E00DF10") };
-            _webFactory.RegisterResultForUri(cf.Uri.AbsoluteUri + "/Test/User/Contract", new PagedCollection<UserContract> { Count = 1, Items = new[] { new UserContract() { UID = _uid } } }.ToJson());
+            var cf = new CompanyFile()
+            {
+                Uri = new Uri("https://dc1.api.myob.com/accountright/7D5F5516-AF68-4C5B-844A-3F054E00DF10")
+            };
+
+            _webFactory.RegisterResultForUri(
+                cf.Uri.AbsoluteUri + "/Test/User/Contract",
+                new PagedCollection<UserContract>
+                {
+                    Count = 1,
+                    Items = new[]
+                    {
+                        new UserContract() { UID = _uid }
+                    }
+                }.ToJson());
+
             HttpWebRequest request = null;
-            _webFactory.CreatedWebRequest += _ => request = (HttpWebRequest)_; 
+            _webFactory.CreatedWebRequest += _ => request = (HttpWebRequest)_;
 
             // act
             var received = action.Item2(_service, cf);
 
             // assert
             Assert.AreEqual("987654321", request.Headers[HttpRequestHeader.IfNoneMatch]);
+        }
+
+        private readonly Func<TestReadOnlyService, CompanyFile, NavigablePagedCollection<UserContract>>[]
+            _getRangeDelegates = {
+                (service, cf) =>
+                {
+                    NavigablePagedCollection<UserContract> received = null;
+                    service.GetRange(
+                        cf,
+                        null,
+                        null,
+                        (code, files) => { received = files; },
+                        (uri, exception) => Assert.Fail(exception.Message),
+                        "987654321");
+
+                    return received;
+                },
+                (service, cf) => service.GetRange(cf, null, null),
+                (service, cf) => service.GetRangeAsync(cf, null, null).Result,
+                (service, cf) => service.GetRangeAsync(cf, null, null, CancellationToken.None).Result
+            };
+
+        [Test]
+        public void GetRange_WhenResponseHasNextPageLink_ShouldBeAbleToGetNextPage(
+            [ValueSource("_getRangeDelegates")]
+            Func<TestReadOnlyService, CompanyFile, NavigablePagedCollection<UserContract>> delegates)
+        {
+            // arrange
+            var cf = new CompanyFile
+            {
+                Uri = new Uri("https://dc1.api.myob.com/accountright/7D5F5516-AF68-4C5B-844A-3F054E00DF10")
+            };
+
+            var nextPageUri = new Uri(cf.Uri.AbsoluteUri + "/Test/User/Contract/?$top=1&$skip=1");
+
+            _webFactory.RegisterResultForUri(
+                cf.Uri.AbsoluteUri + "/Test/User/Contract",
+                new PagedCollection<UserContract>
+                {
+                    Count = 2,
+                    Items = new[] { new UserContract { UID = _uid } },
+                    NextPageLink = nextPageUri
+                }.ToJson());
+
+            _webFactory.RegisterResultForUri(
+                nextPageUri.ToString(),
+                new PagedCollection<UserContract>
+                {
+                    Count = 2,
+                    Items = new[] { new UserContract() }
+                }.ToJson());
+
+            // act
+            var received = _service.GetRange(cf, null, null);
+            var nextPage = received.NextPage();
+
+            // assert
+            Assert.IsInstanceOf<NavigablePagedCollection<UserContract>>(nextPage);
+        }
+
+        [Test]
+        public async Task GetRange_WhenResponseHasNextPageLink_ShouldBeAbleToGetNextPageAsync(
+            [ValueSource("_getRangeDelegates")]
+            Func<TestReadOnlyService, CompanyFile, NavigablePagedCollection<UserContract>> delegates)
+        {
+            // arrange
+            var cf = new CompanyFile
+            {
+                Uri = new Uri("https://dc1.api.myob.com/accountright/7D5F5516-AF68-4C5B-844A-3F054E00DF10")
+            };
+
+            var nextPageUri = new Uri(cf.Uri.AbsoluteUri + "/Test/User/Contract/?$top=1&$skip=1");
+            
+            _webFactory.RegisterResultForUri(
+                cf.Uri.AbsoluteUri + "/Test/User/Contract",
+                new PagedCollection<UserContract>
+                {
+                    Count = 2,
+                    Items = new[] { new UserContract { UID = _uid } },
+                    NextPageLink = nextPageUri
+                }.ToJson());
+
+            _webFactory.RegisterResultForUri(
+                nextPageUri.ToString(),
+                new PagedCollection<UserContract>
+                {
+                    Count = 2,
+                    Items = new[] { new UserContract() }
+                }.ToJson());
+
+            // act
+            var received = _service.GetRange(cf, null, null);
+            var nextPage = await received.NextPageAsync();
+
+            // assert
+            Assert.IsInstanceOf<NavigablePagedCollection<UserContract>>(nextPage);
         }
     }
 }

--- a/MYOB.API.SDK/SDK/Contracts/Version2/NavigablePagedCollection.cs
+++ b/MYOB.API.SDK/SDK/Contracts/Version2/NavigablePagedCollection.cs
@@ -1,0 +1,97 @@
+﻿using System;
+#if ASYNC
+using System.Threading;
+using System.Threading.Tasks;
+#endif
+
+namespace MYOB.AccountRight.SDK.Contracts.Version2
+{
+    /// <summary>
+    /// Extends PagedCollection<> to allow navigation to the next page
+    /// </summary>
+    /// <typeparam name="T">The type of entities that have been returned</typeparam>
+    /// <remarks>
+    /// If NextPageLink is not populated here the NextPage method will return null
+    /// </remarks>
+    public class NavigablePagedCollection<T>
+        : PagedCollection<T>
+        where T : class
+    {
+        private readonly NextPageDelegate _nextPage;
+        internal delegate PagedCollection<T> NextPageDelegate(
+            Uri uri,
+            string eTag);
+
+#if ASYNC
+        private readonly NextPageAsyncDelegate _nextPageAsync;
+        internal delegate Task<PagedCollection<T>> NextPageAsyncDelegate(
+            Uri uri,
+            CancellationToken cancellationToken,
+            string eTag);
+
+        internal NavigablePagedCollection(
+            PagedCollection<T> pagedCollection,
+            NextPageDelegate nextPage,
+            NextPageAsyncDelegate nextPageAsync)
+        {
+            _nextPage = nextPage;
+            _nextPageAsync = nextPageAsync;
+            Items = pagedCollection.Items;
+            NextPageLink = pagedCollection.NextPageLink;
+            Count = pagedCollection.Count;
+            ETag = pagedCollection.ETag;
+        }
+#else
+        internal NavigablePagedCollection(
+            PagedCollection<T> pagedCollection,
+            NextPageDelegate nextPage)
+        {
+            _nextPage = nextPage;
+            Items = pagedCollection.Items;
+            NextPageLink = pagedCollection.NextPageLink;
+            Count = pagedCollection.Count;
+            ETag = pagedCollection.ETag;
+        }
+#endif
+
+        public NavigablePagedCollection<T> NextPage(string eTag = null)
+        {
+            if (NextPageLink == null) return null;
+            var pagedCollection = _nextPage(NextPageLink, eTag);
+            return FromPagedCollection(pagedCollection);
+        }
+
+        public async Task<NavigablePagedCollection<T>> NextPageAsync(
+            CancellationToken cancellationToken,
+            string eTag = null)
+        {
+            if (NextPageLink == null) return null;
+            var pagedCollection = await _nextPageAsync(
+                NextPageLink,
+                cancellationToken,
+                eTag);
+            return FromPagedCollection(pagedCollection);
+
+        }
+
+        public Task<NavigablePagedCollection<T>> NextPageAsync(string eTag = null)
+        {
+            return NextPageAsync(CancellationToken.None, eTag);
+        }
+
+        private NavigablePagedCollection<T> FromPagedCollection(
+            PagedCollection<T> pagedCollection)
+        {
+#if ASYNC
+            return new NavigablePagedCollection<T>(
+                pagedCollection,
+                _nextPage,
+                _nextPageAsync);
+#else
+            return new NavigablePagedCollection<T>(
+                pagedCollection,
+                _nextPage);
+#endif
+        }
+    }
+}

--- a/MYOB.API.SDK/SDK/Services/Version2/IReadable.cs
+++ b/MYOB.API.SDK/SDK/Services/Version2/IReadable.cs
@@ -25,7 +25,7 @@ namespace MYOB.AccountRight.SDK.Services
         /// <param name="onComplete">The action to call when the operation is complete</param>
         /// <param name="onError">The action to call when the operation has an error</param>
         /// <param name="eTag">The <see cref="BaseEntity.ETag" /> from a previously fetched entity</param>
-        void GetRange(CompanyFile cf, string queryString, ICompanyFileCredentials credentials, Action<HttpStatusCode, PagedCollection<T>> onComplete, Action<Uri, Exception> onError, string eTag = null);
+        void GetRange(CompanyFile cf, string queryString, ICompanyFileCredentials credentials, Action<HttpStatusCode, NavigablePagedCollection<T>> onComplete, Action<Uri, Exception> onError, string eTag = null);
 
         /// <summary>
         /// Retrieve a paged list of entities
@@ -35,7 +35,7 @@ namespace MYOB.AccountRight.SDK.Services
         /// <param name="credentials">The credentials to access the company file</param>
         /// <param name="eTag">The <see cref="BaseEntity.ETag" /> from a previously fetched entity</param>
         /// <returns></returns>
-        PagedCollection<T> GetRange(CompanyFile cf, string queryString, ICompanyFileCredentials credentials, string eTag = null);
+        NavigablePagedCollection<T> GetRange(CompanyFile cf, string queryString, ICompanyFileCredentials credentials, string eTag = null);
 
 #if ASYNC
         /// <summary>
@@ -47,7 +47,7 @@ namespace MYOB.AccountRight.SDK.Services
         /// <param name="cancellationToken"></param>
         /// <param name="eTag">The <see cref="BaseEntity.ETag" /> from a previously fetched entity</param>
         /// <returns></returns>
-        Task<PagedCollection<T>> GetRangeAsync(CompanyFile cf, string queryString, ICompanyFileCredentials credentials, CancellationToken cancellationToken, string eTag = null);
+        Task<NavigablePagedCollection<T>> GetRangeAsync(CompanyFile cf, string queryString, ICompanyFileCredentials credentials, CancellationToken cancellationToken, string eTag = null);
 #endif
     }
 


### PR DESCRIPTION
Extendeds `PagedCollection<>` to allow uses to retrieve the `NextPageLink` as a `PagedCollection<>` from the service.

* I have tried to keep the current separation of concerns as well as making sure that there is no breaking changes.
* The ASYNC symbol has been used throughout.
* I have added tests to `ReadableServiceTests` because the feature is implemented there.
* I have removed some trailing whitespace
* I have added line breaks and indentation to long lines to assist with readability.